### PR TITLE
:new: allow schemas to configure error reporting

### DIFF
--- a/luckycharms/base.py
+++ b/luckycharms/base.py
@@ -36,11 +36,17 @@ SHOW_ERRORS = _SHOW_ERR_ENV_VAR in ['True', 'true']
 
 class ErrorHandlingSchema(Schema):
     """Base schema class that knows how to handle errors."""
+
+    def __init__(self, *args, **kwargs):
+        """Extended init method for ErrorHandlingSchema to initialize with configuration."""
+        super(Schema, self).__init__(*args, **kwargs)
+        self.show_errors = getattr(self, 'show_errors', SHOW_ERRORS)
+
     def handle_error(self, error, data):
         """Overridden method to return 400s."""
         msg = ''
         # v may be a dictionary instead of a list
-        if SHOW_ERRORS:
+        if self.show_errors:
             for key, value in error.messages.items():
                 if isinstance(value, dict):
                     val = str(value)


### PR DESCRIPTION
  * setting show_errors=True in a schema means that the exception will have a message with it
  * this also allows you to SHOW_ERRORS globally still
  * by setting show_errors to False, you can disable a schema error message explicitly