### PR TITLE
Allow unconditional paging per QuerystringSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Configuration of the behavior of each schema class is controlled by defining a d
 
 - **querystring_schemas**: [`dict`] - A dictionary containing the keys load and load_many. These keys are used to deserialize and validate the querystring on a GET request. If not supplied, these schemas default to QuerystringResource and QuerystringCollection for the keys mentioned, respectively. QuerystringResource accepts and validates the parameter fields only which is used to indicate which fields are desired in the response. QuerystringCollection accepts and validates the parameters fields, page (if paged is set to True), order_by (which accepts any valid field name for the schema), and order (which accepts any valid order for that field, such as asc or desc).
 
+> **Special Case:** A custom `QuerystringCollection` subclass may set a `config` value for `unconditional_paging`.
+>
+> ```python
+> class CustomQuerystringCollection(QuerystringCollection):
+>     config = {'unconditional_paging': True}
+> ```
+>
+> If `unconditional_paging` is `True` for a `QuerystringCollection`, the "all pages" (`page='*'`) validation is skipped.
 
 ##### Configuring the module
 There are three aspects of the luckycharms module that can be configured with environment variables:

--- a/luckycharms/base.py
+++ b/luckycharms/base.py
@@ -289,10 +289,16 @@ class QuerystringCollection(QuerystringResource):
     @validates_schema(skip_on_field_errors=True)
     def validate_all_pages(self, data):
         """Validate number of fields if page=* is passed."""
+        unconditional_paging = False
+        config = getattr(self, 'config', None)
+        if config:
+            unconditional_paging = bool(config.get('unconditional_paging'))
+
         if data['page'] == '*':
-            fields = data['fields'].split(',')
-            if data['fields'] == '*' or len(fields) > 2:
-                raise ValidationError('Maximum two fields allowed for page=*.')
+            if not unconditional_paging:
+                fields = data['fields'].split(',')
+                if data['fields'] == '*' or len(fields) > 2:
+                    raise ValidationError('Maximum two fields allowed for page=*.')
 
     @validates_schema
     def validate_ordering(self, data):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -435,6 +435,31 @@ def test_paging_validation():
         business_logic()
 
 
+def test_unconditional_paging_validation():
+    """Test the unconditional_paging configuration."""
+
+    class UnconditionalPagingQuerystringCollection(QuerystringCollection):
+        """Custom Querystring Collection Schema that allows unconditional paging."""
+        config = {'unconditional_paging': True}
+
+    class TestSchema(BaseModelSchema):
+        a = fields.Int(order=('desc',))
+        b = fields.String(order=('asc', 'desc'))
+        c = fields.Boolean()
+
+        config = {
+            'querystring_schemas': {
+                'load_many': UnconditionalPagingQuerystringCollection,
+            }
+        }
+
+    @TestSchema(many=True)
+    def business_logic(fields, page, page_size, order, order_by):
+        pass  # pragma: no cover
+
+    with app.test_request_context('/?page=*&fields=*'):
+        business_logic()
+
 def test_ordering_validation():
 
     class TestSchema(BaseModelSchema):


### PR DESCRIPTION
- Modified `validate_all_pages` to consider a `config` value: `unconditional_paging`
- If `unconditional_paging`, skip `fields` validation when `page=*`
- Updated README